### PR TITLE
Read configuration file from root directory of application

### DIFF
--- a/uocloud_sync/uocloud_sync_config.py
+++ b/uocloud_sync/uocloud_sync_config.py
@@ -1,4 +1,5 @@
 import configparser
+import os
 
 
 APP_NAME = 'uocloud_sync'
@@ -9,8 +10,11 @@ class UOCloudSyncConfig:
     Read config from file named uocloud_sync.cfg
     """
     def __init__(self):
+        # Get parent path of this file
+        __location__ = os.path.dirname(os.path.realpath(
+            os.path.join(os.getcwd(), os.path.dirname(__file__))))
         self._config = configparser.ConfigParser()
-        self._config.read([f'{APP_NAME}.cfg'])
+        self._config.read([os.path.join(__location__, f'{APP_NAME}.cfg')])
 
     def get_client_id(self) -> str:
         try:


### PR DESCRIPTION
Read the configuration from the root directory of the application,
instead of from the current working directory.